### PR TITLE
M2M Select via shared relations_sql.SOURCE mixin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/service
 
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN apk add git && pip install -r requirements.txt
 
 COPY setup.py .
 COPY lib lib

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT=gaf3
 IMAGE=python-relations-pymysql
 INSTALL=python:3.8.5-alpine3.12
-VERSION?=0.6.12
+VERSION?=0.6.13
 NETWORK=relations.io
 MYSQL_IMAGE=mysql:8.0.28-oracle
 MYSQL_HOST=$(ACCOUNT)-$(IMAGE)-mysql

--- a/lib/relations_pymysql.py
+++ b/lib/relations_pymysql.py
@@ -505,7 +505,7 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
 
                 update_query = query or self.update_query(updating)
 
-                if update_query.SET:
+                if update_query.SET.expressions:
 
                     update_query.generate()
                     cursor.execute(update_query.sql, update_query.args)

--- a/lib/relations_pymysql.py
+++ b/lib/relations_pymysql.py
@@ -155,7 +155,7 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
         Get query for what's being inserted
         """
 
-        fields = [field.store for field in model._fields._order if not field.auto and not field.inject]
+        fields = [field.store for field in model._fields._order if not field.auto and not field.inject and field.store]
         query = self.INSERT(self.TABLE_NAME(model.STORE, schema=model.SCHEMA), *fields)
 
         if not model._bulk and model._id is not None and model._fields._names[model._id].auto:
@@ -184,6 +184,8 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
         Executes the create
         """
 
+        super().create(model)
+
         cursor = self.connection.cursor()
 
         if not model._bulk and model._id is not None and model._fields._names[model._id].auto:
@@ -200,6 +202,9 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
         if not model._bulk:
 
             for creating in model._each("create"):
+
+                self.create_ties(creating)
+
                 for parent_child in creating.CHILDREN:
                     if creating._children.get(parent_child):
                         creating._children[parent_child].create()

--- a/lib/relations_pymysql.py
+++ b/lib/relations_pymysql.py
@@ -562,6 +562,19 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
 
             delete_query = query or self.delete_query(model)
 
+            if model._id:
+
+                store_id = model._fields._names[model._id].store
+
+                id_query = self.SELECT(store_id, WHERE=delete_query.WHERE).FROM(self.TABLE_NAME(model.STORE, schema=model.SCHEMA))
+
+                id_query.generate()
+
+                cursor.execute(id_query.sql, id_query.args)
+                ids = [row[store_id] for row in cursor.fetchall()]
+
+                self.delete_ties(model, ids)
+
         elif model._id:
 
             delete_query = self.delete_query(model)
@@ -576,7 +589,6 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
 
         delete_query.generate()
         cursor.execute(delete_query.sql, tuple(delete_query.args))
-
         return cursor.rowcount
 
     def definition(self, file_path, source_path):

--- a/lib/relations_pymysql.py
+++ b/lib/relations_pymysql.py
@@ -18,7 +18,7 @@ import relations_sql
 import relations_mysql
 
 
-class Source(relations.Source): # pylint: disable=too-many-public-methods
+class Source(relations_sql.SOURCE, relations.Source): # pylint: disable=too-many-public-methods
     """
     PyMySQL Source
     """
@@ -301,6 +301,7 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
         query = self.SELECT(self.AS("total", self.SQL("COUNT(*)"))).FROM(self.TABLE_NAME(model.STORE, schema=model.SCHEMA))
 
         model._collate()
+        self.collate_ties_query(model, query)
         self.retrieve_record(model._record, query)
         self.like(model, query)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # relations-dil==0.6.14
 # relations-sql==0.6.8
 # relations-mysql==0.6.4
-relations-dil @ git+https://github.com/relations-dil/python-relations@c742bd922b963b614199b949ac936c38f74550ff
-relations-sql @ git+https://github.com/relations-dil/python-relations-sql@5bbd72bab4fd76ecbe8dcbe2ba2101e95f03f335
-relations-mysql @ git+https://github.com/relations-dil/python-relations-mysql@bc73c22e23b1e77bfa53757ae7a191ca373a5ddb
+relations-dil @ git+https://github.com/relations-dil/python-relations@09f27c34eb079dd29042cb9460b140fea336b9f3
+relations-sql @ git+https://github.com/relations-dil/python-relations-sql@c0e672d97e2b5a8ed3505f7c9cf734fee2e29881
+relations-mysql @ git+https://github.com/relations-dil/python-relations-mysql@67ffd7796f44cc0c267c1728849fa4d1c48d7fd7
 PyMySQL==0.10.0
 ptvsd==4.3.2
 coverage==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # relations-dil==0.6.14
 # relations-sql==0.6.8
 # relations-mysql==0.6.4
-relations-dil @ git+https://github.com/relations-dil/python-relations@09f27c34eb079dd29042cb9460b140fea336b9f3
+relations-dil @ git+https://github.com/relations-dil/python-relations@ab8af7bb24bceab2286175c8df5626137294f46d
 relations-sql @ git+https://github.com/relations-dil/python-relations-sql@c0e672d97e2b5a8ed3505f7c9cf734fee2e29881
 relations-mysql @ git+https://github.com/relations-dil/python-relations-mysql@67ffd7796f44cc0c267c1728849fa4d1c48d7fd7
 PyMySQL==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
-relations-dil==0.6.12
-relations-mysql==0.6.3
+# relations-dil==0.6.14
+# relations-sql==0.6.8
+# relations-mysql==0.6.4
+relations-dil @ git+https://github.com/relations-dil/python-relations@c742bd922b963b614199b949ac936c38f74550ff
+relations-sql @ git+https://github.com/relations-dil/python-relations-sql@5bbd72bab4fd76ecbe8dcbe2ba2101e95f03f335
+relations-mysql @ git+https://github.com/relations-dil/python-relations-mysql@bc73c22e23b1e77bfa53757ae7a191ca373a5ddb
 PyMySQL==0.10.0
 ptvsd==4.3.2
 coverage==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-# relations-dil==0.6.14
-# relations-sql==0.6.8
-# relations-mysql==0.6.4
-relations-dil @ git+https://github.com/relations-dil/python-relations@7b83a060fcd41ee2ae81bb63aae5fc6a7e530cfa
-relations-sql @ git+https://github.com/relations-dil/python-relations-sql@3a6698ab9f77de75ee729aa6b5608fc6db69c286
-relations-mysql @ git+https://github.com/relations-dil/python-relations-mysql@67ffd7796f44cc0c267c1728849fa4d1c48d7fd7
+relations-dil==0.6.14
+relations-sql==0.6.8
+relations-mysql==0.6.4
 PyMySQL==0.10.0
 ptvsd==4.3.2
 coverage==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # relations-dil==0.6.14
 # relations-sql==0.6.8
 # relations-mysql==0.6.4
-relations-dil @ git+https://github.com/relations-dil/python-relations@ab8af7bb24bceab2286175c8df5626137294f46d
-relations-sql @ git+https://github.com/relations-dil/python-relations-sql@c0e672d97e2b5a8ed3505f7c9cf734fee2e29881
+relations-dil @ git+https://github.com/relations-dil/python-relations@7b83a060fcd41ee2ae81bb63aae5fc6a7e530cfa
+relations-sql @ git+https://github.com/relations-dil/python-relations-sql@3a6698ab9f77de75ee729aa6b5608fc6db69c286
 relations-mysql @ git+https://github.com/relations-dil/python-relations-mysql@67ffd7796f44cc0c267c1728849fa4d1c48d7fd7
 PyMySQL==0.10.0
 ptvsd==4.3.2

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setup(
     ],
     install_requires=[
         'PyMySQL==0.10.0',
-        'relations-dil>=0.6.13',
-        'relations-mysql>=0.6.3'
+        'relations-dil>=0.6.14',
+        'relations-mysql>=0.6.4'
     ],
     url="https://github.com/relations-dil/python-relations-pymysql",
     author="Gaffer Fitch",

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,14 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="relations-pymysql",
-    version="0.6.12",
+    version="0.6.13",
     package_dir = {'': 'lib'},
     py_modules = [
         'relations_pymysql'
     ],
     install_requires=[
         'PyMySQL==0.10.0',
-        'relations-dil>=0.6.12',
+        'relations-dil>=0.6.13',
         'relations-mysql>=0.6.3'
     ],
     url="https://github.com/relations-dil/python-relations-pymysql",

--- a/test/test_relations_pymysql.py
+++ b/test/test_relations_pymysql.py
@@ -1101,6 +1101,7 @@ LIMIT %s""")
         Sis.many(name="Sally").delete()
 
         self.assertEqual(Bro.one(name="Harry").sis.id, [])
+        self.assertEqual(SisBro.many().count(), 0)
 
         tom = Bro("Tom").create()
         dick = Bro("Dick").create()
@@ -1114,8 +1115,8 @@ LIMIT %s""")
         tom.update()
         dot.update()
 
-        Bro.many(name="Dick").delete()
-        Sis.many(name="Nikki").delete()
+        Bro.one(name="Dick").retrieve().delete()
+        Sis.one(name="Nikki").retrieve().delete()
 
         self.assertEqual(Bro.one(name="Tom").sis.id, [dot.id])
         self.assertEqual(Sis.one(name="Dot").bro.id, [tom.id])

--- a/test/test_relations_pymysql.py
+++ b/test/test_relations_pymysql.py
@@ -1098,7 +1098,7 @@ LIMIT %s""")
         bro = Bro("Harry").create()
         Sis.many(name="Sally").set(bro_id=[bro.id]).update()
 
-        Sis.one(name="Sally").delete()
+        Sis.many(name="Sally").delete()
 
         self.assertEqual(Bro.one(name="Harry").sis.id, [])
 
@@ -1114,8 +1114,8 @@ LIMIT %s""")
         tom.update()
         dot.update()
 
-        dick.one(name="Dick").retrieve().delete()
-        nikki.one(name="Nikki").retrieve().delete()
+        Bro.many(name="Dick").delete()
+        Sis.many(name="Nikki").delete()
 
         self.assertEqual(Bro.one(name="Tom").sis.id, [dot.id])
         self.assertEqual(Sis.one(name="Dot").bro.id, [tom.id])

--- a/test/test_relations_pymysql.py
+++ b/test/test_relations_pymysql.py
@@ -632,8 +632,16 @@ LIMIT %s""")
 
         self.assertEqual(Unit.many(like="p").count(), 1)
 
-        sis = Sis.many(bro_id=[2, 3, 4])
-        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.count)
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
+
+        tom = Bro("Tom").create()
+        Sis("Sally", bro_id=[tom.id]).create()
+        Sis("Mary").create()
+
+        self.assertEqual(Sis.many(bro_id=[tom.id]).count(), 1)
+        self.assertEqual(Sis.many(bro_id=[999]).count(), 0)
 
     def test_values_retrieve(self):
 
@@ -844,9 +852,6 @@ LIMIT %s""")
         model = Net.many(subnet__max_value=int(ipaddress.IPv4Address('1.2.3.0')))
         self.assertEqual(len(model), 0)
 
-        sis = Sis.many(bro_id=[2, 3, 4])
-        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.retrieve)
-
         tom = Bro("Tom").create()
         dick = Bro("Dick").create()
 
@@ -858,6 +863,64 @@ LIMIT %s""")
 
         self.assertEqual(mary.bro.id, [dick.id, tom.id])
         self.assertEqual(harry.sis.id, [dot.id, nikki.id])
+
+        self.assertEqual(len(Sis.many(bro_id=[tom.id])), 1)
+        self.assertEqual(Sis.many(bro_id=[tom.id])[0].name, "Mary")
+
+        self.assertEqual(len(Bro.many(sis_id=[dot.id])), 1)
+        self.assertEqual(Bro.many(sis_id=[dot.id])[0].name, "Harry")
+
+        self.assertEqual(len(Sis.many(bro_id=[999])), 0)
+
+    def test_retrieve_ties_query(self):
+
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
+
+        # The tie field is a set, so it's queried with set operators (has/any/all),
+        # resolved through the tie table. A sister has many brothers, so "any of" and
+        # "all of" are genuinely different queries.
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+        harry = Bro("Harry").create()
+
+        Sis("Mary", bro_id=[tom.id, dick.id]).create()   # tied to Tom, Dick
+        Sis("Sue", bro_id=[tom.id]).create()             # tied to Tom
+        Sis("Ann", bro_id=[dick.id, harry.id]).create()  # tied to Dick, Harry
+
+        # has: tied to that one brother
+        self.assertEqual(sorted(Sis.many(bro_id__has=tom.id).name), ["Mary", "Sue"])
+        self.assertEqual(Sis.many(bro_id__has=harry.id).name, ["Ann"])
+        self.assertEqual(len(Sis.many(bro_id__has=999)), 0)
+
+        # any: tied to at least one of them
+        self.assertEqual(sorted(Sis.many(bro_id__any=[tom.id, harry.id]).name), ["Ann", "Mary", "Sue"])
+        self.assertEqual(Sis.many(bro_id__any=[harry.id]).name, ["Ann"])
+        self.assertEqual(len(Sis.many(bro_id__any=[999])), 0)
+
+        # all: tied to every one of them
+        self.assertEqual(Sis.many(bro_id__all=[tom.id, dick.id]).name, ["Mary"])
+        self.assertEqual(sorted(Sis.many(bro_id__all=[dick.id]).name), ["Ann", "Mary"])
+        self.assertEqual(len(Sis.many(bro_id__all=[tom.id, harry.id])), 0)
+
+        # all must de-dupe the requested list (a repeated value can't change the result)
+        self.assertEqual(sorted(Sis.many(bro_id__all=[dick.id, dick.id]).name), ["Ann", "Mary"])
+
+        # negation
+        self.assertEqual(Sis.many(bro_id__not_has=tom.id).name, ["Ann"])
+        self.assertEqual(sorted(Sis.many(bro_id__not_any=[harry.id]).name), ["Mary", "Sue"])
+
+        # symmetric: brothers queried by their tied sisters
+        jane = Sis("Jane").create()
+        joan = Sis("Joan").create()
+        Bro("Bob", sis_id=[jane.id, joan.id]).create()   # tied to Jane, Joan
+        Bro("Bill", sis_id=[jane.id]).create()           # tied to Jane
+
+        self.assertEqual(sorted(Bro.many(sis_id__has=jane.id).name), ["Bill", "Bob"])
+        self.assertEqual(Bro.many(sis_id__all=[jane.id, joan.id]).name, ["Bob"])
+        self.assertEqual(Bro.many(sis_id__any=[joan.id]).name, ["Bob"])
 
     def test_titles(self):
 
@@ -906,8 +969,10 @@ LIMIT %s""")
             1: ["1.2.3.4"]
         })
 
-        sis = Sis.many(bro_id=[2, 3, 4])
-        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.titles)
+        tom = Bro("Tom").create()
+        Sis("Sally", bro_id=[tom.id]).create()
+
+        self.assertEqual(len(Sis.many(bro_id=[tom.id]).titles().ids), 1)
 
     def test_update_field(self):
 


### PR DESCRIPTION
Closes #51.

Many-to-Many for this backend (create/update/delete + Select), with M2M Select resolved as an **in-database subquery** via the shared `relations_sql.SOURCE` mixin — no reading ties into Python.

- Inherits `collate_ties`/`collate_ties_query` from `relations_sql.SOURCE` (relations-dil/python-relations-sql#21); local copy removed.
- Functional `test_retrieve_ties_query` validates has/any/all/not_ against a real MySQL. 100% via `make test` **and** `make lint`.

**Supersedes #47** — that branch's CUD commits are already merged into this one.

Merge order — land first: core relations-dil/python-relations#62 and the mixin relations-dil/python-relations-sql#21 (this pins both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)