### PR TITLE
M2M attr: sibling-attribute filtering (pymysql)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT=gaf3
 IMAGE=python-relations-pymysql
 INSTALL=python:3.8.5-alpine3.12
-VERSION?=0.6.14
+VERSION?=0.6.15
 NETWORK?=relations.io
 MYSQL_IMAGE=mysql:8.0.28-oracle
 MYSQL_HOST=$(ACCOUNT)-$(IMAGE)-mysql-$(NETWORK)

--- a/lib/relations_pymysql.py
+++ b/lib/relations_pymysql.py
@@ -33,7 +33,9 @@ class Source(relations_sql.SOURCE, relations.Source): # pylint: disable=too-many
     OP = relations_mysql.OP
 
     AS = relations_mysql.AS
+    OPTIONS = relations_mysql.OPTIONS
     FIELDS = relations_mysql.FIELDS
+    COLUMN_NAME = relations_mysql.COLUMN_NAME
     TABLE = relations_mysql.TABLE
     TABLE_NAME = relations_mysql.TABLE_NAME
 
@@ -305,6 +307,11 @@ class Source(relations_sql.SOURCE, relations.Source): # pylint: disable=too-many
         self.retrieve_record(model._record, query)
         self.like(model, query)
 
+        # a sibling-attribute flat join repeats a model tied to several matching siblings, so
+        # count the distinct model id instead of the joined rows
+        if getattr(model, "_distinct", False):
+            query.FIELDS = self.FIELDS(self.AS("total", self.SQL(f"COUNT(DISTINCT {model.STORE}.{model._id})")))
+
         return query
 
     def retrieve_query(self, model):
@@ -314,7 +321,12 @@ class Source(relations_sql.SOURCE, relations.Source): # pylint: disable=too-many
 
         query = self.count_query(model)
 
-        query.FIELDS = self.FIELDS("*")
+        # honor the flat-join DISTINCT marker: dedupe the model rows the join multiplied
+        if getattr(model, "_distinct", False):
+            query.OPTIONS = self.OPTIONS("DISTINCT")
+            query.FIELDS = self.FIELDS(self.COLUMN_NAME("*", table=model.STORE))
+        else:
+            query.FIELDS = self.FIELDS("*")
 
         self.sort(model, query)
         self.limit(model, query)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-relations-dil==0.6.14
-relations-sql==0.6.8
+relations-dil @ git+https://github.com/relations-dil/python-relations@aa309087789d4b7ed459676c4343f61bb95a4af5
+relations-sql @ git+https://github.com/relations-dil/python-relations-sql@7d8be2cfa9921a3321a123fa668640002b031f9e
 relations-mysql==0.6.4
 PyMySQL==0.10.0
 ptvsd==4.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-relations-dil @ git+https://github.com/relations-dil/python-relations@aa309087789d4b7ed459676c4343f61bb95a4af5
-relations-sql @ git+https://github.com/relations-dil/python-relations-sql@7d8be2cfa9921a3321a123fa668640002b031f9e
+relations-dil==0.6.15
+relations-sql==0.6.9
 relations-mysql==0.6.4
 PyMySQL==0.10.0
 ptvsd==4.3.2

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="relations-pymysql",
-    version="0.6.14",
+    version="0.6.15",
     package_dir = {'': 'lib'},
     py_modules = [
         'relations_pymysql'

--- a/test/test_relations_pymysql.py
+++ b/test/test_relations_pymysql.py
@@ -922,6 +922,52 @@ LIMIT %s""")
         self.assertEqual(Bro.many(sis_id__all=[jane.id, joan.id]).name, ["Bob"])
         self.assertEqual(Bro.many(sis_id__any=[joan.id]).name, ["Bob"])
 
+    def test_retrieve_ties_attr(self):
+
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
+
+        # M2M attribute filtering: a flat join through the tie table filters on the sibling's
+        # own field. Existence semantics, with the sibling's normal field operators.
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+        harry = Bro("Harry").create()
+
+        Sis("Mary", bro_id=[tom.id, dick.id]).create()   # tied to Tom, Dick
+        Sis("Sue", bro_id=[tom.id]).create()             # tied to Tom
+        Sis("Ann", bro_id=[dick.id, harry.id]).create()  # tied to Dick, Harry
+
+        # tied to a brother with that name
+        self.assertEqual(sorted(Sis.many(bro__name="Tom").name), ["Mary", "Sue"])
+        self.assertEqual(Sis.many(bro__name="Harry").name, ["Ann"])
+        self.assertEqual(len(Sis.many(bro__name="Ghost")), 0)
+
+        # field operators land on the sibling: like
+        self.assertEqual(Sis.many(bro__name__like="arr").name, ["Ann"])
+
+        # DISTINCT: Mary is tied to BOTH Tom and Dick, so an "in" join would match her twice;
+        # she must appear once (retrieve) and count once
+        self.assertEqual(sorted(Sis.many(bro__name__in=["Tom", "Dick"]).name), ["Ann", "Mary", "Sue"])
+        self.assertEqual(Sis.many(bro__name__in=["Tom", "Dick"]).count(), 3)
+
+        # negation is field-level: a tied non-Tom exists (Mary stays via Dick)
+        self.assertEqual(sorted(Sis.many(bro__name__not_in=["Tom"]).name), ["Ann", "Mary"])
+
+        # criteria on the same relation filter the SAME tied brother
+        self.assertEqual(Sis.many(bro__name="Dick", bro__id=harry.id).name, [])
+        self.assertEqual(sorted(Sis.many(bro__name="Dick", bro__id=dick.id).name), ["Ann", "Mary"])
+
+        # symmetric: brothers filtered by a tied sister's name
+        jane = Sis("Jane").create()
+        joan = Sis("Joan").create()
+        Bro("Bab", sis_id=[jane.id, joan.id]).create()   # tied to Jane, Joan
+        Bro("Bil", sis_id=[jane.id]).create()            # tied to Jane
+
+        self.assertEqual(sorted(Bro.many(sis__name="Jane").name), ["Bab", "Bil"])
+        self.assertEqual(Bro.many(sis__name__in=["Joan"]).name, ["Bab"])
+
     def test_titles(self):
 
         self.source.execute(Unit.define())


### PR DESCRIPTION
## M2M attr — sibling-attribute filtering (pymysql)

Resolves `Sis.many(bro__name="Tom")` end-to-end against MySQL, on top of relations-dil#69 and relations-sql#23.

- Honors the flat-join `_distinct` marker: `count_query` → `COUNT(DISTINCT id)`, `retrieve_query` → `SELECT DISTINCT model.*` (only when an attr join was added).
- Adds `COLUMN_NAME` + `OPTIONS` to the Source.
- Functional test on a real DB including the DISTINCT case (sister tied to both Tom and Dick returns once, counts 3).

Pinned to `relations-dil==0.6.15`, `relations-sql==0.6.9`. Gates green: build → test (32, 100%) → lint (10.00) → setup.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
